### PR TITLE
fast-forward: add on.workflow_call

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -13,15 +13,17 @@ jobs:
           ))
       }}
     name: Fast Forward
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     steps:
-      - name: Fast Forwarding
-        uses: "sequoia-pgp/fast-forward@v1"
-        with:
-          comment: on-error
-          merge: 'true'
+    - name: Fast Forwarding
+      uses: "sequoia-pgp/fast-forward@v1"
+      with:
+        comment: "on-error"
+        merge: 'true'
 name: Fast Forward
 on:
   pull_request_review:
     types:
-      - submitted
+    - submitted
+  workflow_call: {}
+

--- a/fast-forward/workflow.dhall
+++ b/fast-forward/workflow.dhall
@@ -1,6 +1,6 @@
 let GithubActions =
       https://regadas.dev/github-actions-dhall/package.dhall
-        sha256:dfb18adac8746b64040c5387d51769177ce08a2d2a496da2446eb244f34cc21e
+        sha256:56b2d746cf5bf75b66276f5adaa057201bbe1ebf29836f4e35390e2a2bb68965
 
 let workflow =
           ../workflow-defaults.dhall
@@ -9,6 +9,7 @@ let workflow =
             , pull_request_review = Some GithubActions.PullRequestReview::{
               , types = Some [ "submitted" ]
               }
+              , workflow_call = Some GithubActions.WorkflowCall::{=}
             }
           , jobs = toMap
               { fast-forward = GithubActions.Job::{


### PR DESCRIPTION
This is needed when calling the workflow from another repository.

Produced using:
dhall 1.42.2
dhall-to-yaml-ng 1.2.12